### PR TITLE
Piccolo typo: 'talk' invece di 'talks':

### DIFF
--- a/src/content/meetups.md
+++ b/src/content/meetups.md
@@ -1,4 +1,4 @@
-###Non solo "talks"
+###Non solo "talk"
 L'idea di base del nostro gruppo è quella fare in modo che ogni partecipante, finito l'incontro, se ne possa andare via con qualcosa in più. Per questo motivo cercheremo il più possibile di rendere gli incontri interattivi, di uscire dal solito schema del talk "classico".
 Questo vuol dire che parleremo di cose concrete, condividendo esperienze e problemi incontrati durante lo sviluppo di applicazioni reali. Cercheremo di mettere mano al codice e di buttare giù una base che potrà poi essere ampliata da ognuno per apprendere e sperimentare.
 Non mancheranno ovviamente i talk dove verrà presentata e spiegata una tecnologia. Diciamo solo che noi preferiamo sporcarci le mani.

--- a/src/content/talks.md
+++ b/src/content/talks.md
@@ -1,4 +1,4 @@
-###Talks in programma:
+###Talk in programma:
 
 1. Benvenuti a Milano JS (Maurizio Mangione)
 2. Introduzione ad Angular JS (Jacopo Nardiello)


### PR DESCRIPTION
Ma niente: un minuscolo typo: In italiano le parole straniere sono invarianti.
Ho corretto "talks" sostituendolo con "talk".
